### PR TITLE
Fix basket icon overlapping navigation elements on hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -127,6 +127,7 @@ input[type="text"]:focus {
   justify-content: center;
   position: relative;
   text-align: center;
+  z-index: 1;
 }
 .basket-text {
   display: block;
@@ -420,6 +421,8 @@ input[type="text"]:focus {
   display: flex;
   align-items: center;
   gap: 1.5rem;
+  z-index: 2;
+  position: relative;
 }
 
 .nav-links a {


### PR DESCRIPTION
## Summary
Fixes the z-index issue where the basket icon's hover effect overlaps and covers other navigation elements.

## Problem
When hovering over the basket icon, its scale and rotate transform causes it to overlap the fruit quiz navigation link and other elements, making them temporarily inaccessible.

## Solution
- Added z-index: 1 to .basket-link to keep it below navigation elements
- Added z-index: 2 and position: relative to .nav-links for proper stacking context
- Maintains all existing hover animations and visual effects

## Changes Made
- Updated CSS z-index layering for proper element stacking
- No visual changes to existing design or animations
- Ensures all navigation elements remain accessible during hover states

## Testing
- ✅ Basket icon hover animation still works smoothly
- ✅ Navigation links remain clickable and visible during basket hover
- ✅ No visual regression in design or layout
- ✅ Works across different screen sizes

Closes #7