### PR TITLE
Fix basket indicator positioning - move closer to basket icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -234,7 +234,7 @@ input[type="text"]:focus {
 .basket-indicator {
   position: absolute;
   bottom: 4rem;
-  right: 3rem;
+  right: 1rem;
   background: #e53935;
   color: #fff;
   border: 2.5px solid #111;


### PR DESCRIPTION
## Summary
Fixes the positioning of the basket indicator (red circle showing item count) to appear closer to the basket icon for better visual connection.

## Problem
The basket indicator was positioned too far to the right (3rem) making it look disconnected from the basket icon and creating poor visual hierarchy.

## Solution
- Changed \ight\ position from \3rem\ to \1rem\
- Basket indicator now appears as a proper notification badge
- Maintains all existing styling and functionality
- Better visual connection between basket and indicator

## Changes Made
- Updated \.basket-indicator\ CSS rule in style.css
- Single line change: \ight: 3rem;\ → \ight: 1rem;\
- No other visual or functional changes

## Testing
- ✅ Basket indicator appears closer to basket icon
- ✅ Still clearly visible and readable
- ✅ Maintains proper z-index layering
- ✅ Works on both desktop and mobile layouts
- ✅ All existing functionality preserved

Closes #9